### PR TITLE
Inherit 'Mojave CT' icons instead of 'MacOS Sierra CT'.

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=phizos icon pack
-Comment=alpha 
-Inherits=Macos-sierra-CT,gnome,hicolor,Numix
+Comment=alpha
+Inherits=Mojave-CT,gnome,hicolor,Numix
 
 # Directory list
 Directories=apps/64,


### PR DESCRIPTION
The required icon pack link on [gnome-look](https://www.opendesktop.org/p/1212439/) page now has 'MacOS Sierra CT' icon pack instead of 'Mojave CT'.